### PR TITLE
Modify network share template to show used space

### DIFF
--- a/lovelace/lovelace/templates/network_share.yaml
+++ b/lovelace/lovelace/templates/network_share.yaml
@@ -58,10 +58,19 @@ button_network_share:
         var free = parseInt(entity.attributes.free);
         var used = parseInt(entity.attributes.used);
 
-        var spaceFree = Math.max(0, free * 1000);
+        var spaceUsed = Math.max(0, used * 1000);
         var spaceTotal = (free+used) * 1000;
 
-        return `${formatBytes(spaceFree, 0)} free of ${formatBytes(spaceTotal, 0)}`;
+        // Determine decimal places based on size
+        var sizeIndex = Math.floor(Math.log(spaceUsed)/Math.log(1000));
+        var decimals = 0;
+        if (sizeIndex === 3) { // GB
+          decimals = 1;
+        } else if (sizeIndex >= 4) { // TB or above
+          decimals = 2;
+        }
+
+        return `${formatBytes(spaceUsed, decimals)} used of ${formatBytes(spaceTotal, 0)}`;
       ]]]
     bar: >
       [[[


### PR DESCRIPTION
Update state calculation to use used space and adjust decimal places based on size. I personally find displaying the amount used is more useful as different shares will share the same disks.

<img width="476" height="459" alt="image" src="https://github.com/user-attachments/assets/8e405206-1e86-4b4f-85c4-67ee1d0babae" />
